### PR TITLE
Updated bookinfo-demo ingress template

### DIFF
--- a/bookinfo-deployable.yaml
+++ b/bookinfo-deployable.yaml
@@ -954,7 +954,7 @@ metadata:
     prereq: "no"
 spec:
   template:
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: bookinfo-demo


### PR DESCRIPTION
Updated ingress template to apiVersion: networking.k8s.io/v1beta1 instead of extensions/v1beta1. I had trouble getting OCP to create this ingress object through a deployable until I made this change. It's odd because extracting the ingress template into a YAML and creating the ingress using oc apply -f worked fine, but deployable was failing. Deployable worked fine with the change, which is the current kubernetes standard.