### PR TITLE
Manage runtimes labels

### DIFF
--- a/bookinfo-multicluster-2020.2.0/01-productpage-deployable.yaml
+++ b/bookinfo-multicluster-2020.2.0/01-productpage-deployable.yaml
@@ -51,6 +51,7 @@ spec:
     metadata:
       name: bookinfo-demo-productpage
       labels:
+        runtime: python
         app.kubernetes.io/name: productpage
         app.kubernetes.io/instance: bookinfo-demo
     spec:
@@ -62,6 +63,7 @@ spec:
       template:
         metadata:
           labels:
+            runtime: python
             app.kubernetes.io/name: productpage
             app.kubernetes.io/instance: bookinfo-demo
         spec:

--- a/bookinfo-multicluster-2020.2.0/02-details-deployable.yaml
+++ b/bookinfo-multicluster-2020.2.0/02-details-deployable.yaml
@@ -50,6 +50,7 @@ spec:
     metadata:
       name: bookinfo-demo-details
       labels:
+        runtime: go
         app.kubernetes.io/name: details
         app.kubernetes.io/instance: bookinfo-demo
     spec:
@@ -61,6 +62,7 @@ spec:
       template:
         metadata:
           labels:
+            runtime: go
             app.kubernetes.io/name: details
             app.kubernetes.io/instance: bookinfo-demo
         spec:
@@ -90,4 +92,4 @@ spec:
                   path: /health
                   port: http
               resources:
-                {}            
+                {}

--- a/bookinfo-multicluster-2020.2.0/03-reviews-deployable.yaml
+++ b/bookinfo-multicluster-2020.2.0/03-reviews-deployable.yaml
@@ -51,6 +51,7 @@ spec:
     metadata:
       name: bookinfo-demo-reviews
       labels:
+        runtime: liberty
         app.kubernetes.io/name: reviews
         app.kubernetes.io/instance: bookinfo-demo
     spec:
@@ -62,6 +63,7 @@ spec:
       template:
         metadata:
           labels:
+            runtime: liberty
             app.kubernetes.io/name: reviews
             app.kubernetes.io/instance: bookinfo-demo
         spec:
@@ -95,7 +97,7 @@ spec:
                 initialDelaySeconds: 120
               failureThreshold: 10
               resources:
-                {}                
+                {}
           securityContext:
 
 ---

--- a/bookinfo-multicluster-2020.2.0/04-ratings-deployable.yaml
+++ b/bookinfo-multicluster-2020.2.0/04-ratings-deployable.yaml
@@ -51,6 +51,7 @@ spec:
     metadata:
       name: bookinfo-demo-ratings
       labels:
+        runtime: node
         app.kubernetes.io/name: ratings
         app.kubernetes.io/instance: bookinfo-demo
     spec:
@@ -62,6 +63,7 @@ spec:
       template:
         metadata:
           labels:
+            runtime: node
             app.kubernetes.io/name: ratings
             app.kubernetes.io/instance: bookinfo-demo
         spec:
@@ -101,5 +103,4 @@ spec:
                   path: /health
                   port: http
               resources:
-                {}                
-
+                {}


### PR DESCRIPTION
- Add runtime labels to enable bookinfo to show on manage runtimes page out of the box